### PR TITLE
[fix] 구독 정보 불러오는 dto 수정

### DIFF
--- a/src/main/java/com/example/monthlylifebackend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/controller/SubscribeController.java
@@ -5,6 +5,7 @@ import com.example.monthlylifebackend.subscribe.dto.req.PostRentalDeliveryReq;
 import com.example.monthlylifebackend.subscribe.dto.req.PostReturnDeliveryReq;
 import com.example.monthlylifebackend.subscribe.dto.req.PostSubscribeReq;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeDetailInfoRes;
+import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeListRes;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribePageResDto;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeRes;
 import com.example.monthlylifebackend.subscribe.facade.SubscribeFacade;
@@ -14,6 +15,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -91,14 +96,22 @@ public class SubscribeController {
 
     @Operation(summary = "구독 정보 조회", description = "현재 내가 구독하고있는 목록을 확인합니다.")
     @GetMapping("/info")
-    public BaseResponse<List<GetSubscribeRes>> getSubscriptionInfo() {
+    public BaseResponse<Page<GetSubscribeListRes>> getSubscriptionInfo(@RequestParam(defaultValue = "0") int page,
+                                                                       @RequestParam(defaultValue = "5") int size) {
+
+
 
         // Todo 삭제할것
         User user = User.builder().id("1").build();
 
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by("idx").descending()
+        );
 
 
-        List<GetSubscribeRes>  rs =subscribeFacade.getSubscriptionInfo(user);
+        Page<GetSubscribeListRes> rs = subscribeFacade.getSubscriptionInfo(user, pageable);
         return BaseResponse.onSuccess(rs);
 
     }
@@ -115,4 +128,7 @@ public class SubscribeController {
         GetSubscribeDetailInfoRes rs =subscribeFacade.getReturnDelivery(user,subscribeDetailIdx);
         return BaseResponse.onSuccess(rs);
     }
+
+
+
 }

--- a/src/main/java/com/example/monthlylifebackend/subscribe/dto/res/GetSubscribeListDto.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/dto/res/GetSubscribeListDto.java
@@ -1,0 +1,35 @@
+package com.example.monthlylifebackend.subscribe.dto.res;
+
+import com.example.monthlylifebackend.subscribe.model.SubscribeStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetSubscribeListDto {
+
+
+    private  Long saleidx;
+    private Long subscribeDetailIdx;
+    private String salename;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    @Schema(description = "구독 기간 (개월)", example = "3")
+    private int period;
+
+    @Schema(description = "상품 가격", example = "29900")
+    private int price;
+
+    @Schema(description = "구독 상태", example = "SUBSCRIBING")
+    private SubscribeStatus status;
+
+    @Schema(description = "상품 이미지 URL", example = "https://image.server.com/product/1.jpg")
+    private String productImgurl;
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/dto/res/GetSubscribeListProjection.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/dto/res/GetSubscribeListProjection.java
@@ -1,0 +1,19 @@
+package com.example.monthlylifebackend.subscribe.dto.res;
+
+import java.time.LocalDateTime;
+
+public interface GetSubscribeListProjection {
+
+    Long getSubscribeIdx();
+    Long getSubscribeDetailIdx();
+    Long getSaleidx();
+    String getSalename();
+    int getPeriod();
+    int getPrice();
+    String getStatus();
+    String getProductCode();
+    String getProductImgurl();
+    LocalDateTime getCreated_at();
+    LocalDateTime getStartAt();
+    LocalDateTime getEndAt();
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/dto/res/GetSubscribeListRes.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/dto/res/GetSubscribeListRes.java
@@ -1,0 +1,37 @@
+package com.example.monthlylifebackend.subscribe.dto.res;
+
+
+import com.example.monthlylifebackend.subscribe.model.SubscribeStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+
+public class GetSubscribeListRes {
+
+    private Long subscribeIdx;
+
+
+    private LocalDateTime createdAt;
+
+
+
+
+    private List<GetSubscribeListDto> details;
+
+    public GetSubscribeListRes(Long subscribeIdx, LocalDateTime createdAt,List<GetSubscribeListDto> details) {
+        this.details = details;
+        this.subscribeIdx = subscribeIdx;
+        this.createdAt = createdAt;
+    }
+
+
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/facade/SubscribeFacade.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/facade/SubscribeFacade.java
@@ -8,6 +8,7 @@ import com.example.monthlylifebackend.subscribe.dto.req.PostRentalDeliveryReq;
 import com.example.monthlylifebackend.subscribe.dto.req.PostReturnDeliveryReq;
 import com.example.monthlylifebackend.subscribe.dto.req.PostSubscribeReq;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeDetailInfoRes;
+import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeListRes;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribePageResDto;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeRes;
 import com.example.monthlylifebackend.subscribe.model.Subscribe;
@@ -15,6 +16,8 @@ import com.example.monthlylifebackend.subscribe.service.SubscribeService;
 import com.example.monthlylifebackend.user.model.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -27,8 +30,8 @@ public class SubscribeFacade {
     private final BillingKeyService billingKeyService;
 
 
-    public List<GetSubscribeRes> getSubscriptionInfo(User user) {
-        return subscribeService.getSubscriptionInfo(user);
+    public Page<GetSubscribeListRes> getSubscriptionInfo(User user, Pageable pageable) {
+        return subscribeService.getSubscriptionInfo(user.getId() ,pageable);
     }
 
 
@@ -57,5 +60,6 @@ public class SubscribeFacade {
         return subscribeService.getSubscription(user.getId()
                 , saleidx, period);
     }
+
 
 }

--- a/src/main/java/com/example/monthlylifebackend/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/repository/SubscribeRepository.java
@@ -1,6 +1,7 @@
 package com.example.monthlylifebackend.subscribe.repository;
 
 
+import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeListProjection;
 import com.example.monthlylifebackend.subscribe.dto.response.GetDeliveryListRes;
 import com.example.monthlylifebackend.subscribe.model.Subscribe;
 import org.springframework.data.domain.Page;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -56,6 +58,55 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
             """)
     List<GetDeliveryListRes> findDeliveryList();
 
-    @Query("SELECT s FROM Subscribe s JOIN FETCH s.subscribeDetailList d JOIN FETCH d.sale WHERE s.user.id = :userId")
-    List<Subscribe> findWithDetailsByUserId(@Param("userId") String userId);
+
+
+
+    @Query("""
+      SELECT sub.idx
+      FROM Subscribe sub
+      WHERE sub.user.id = :userId
+    """)
+    Page<Long> findSubscriptionIdsByUser(
+            @Param("userId") String userId,
+            Pageable pageable
+    );
+
+    @Query(
+            value = """
+        SELECT
+          sd.idx            AS subscribeDetailIdx,
+          s.idx             AS saleIdx,
+          s.name            AS saleName,
+          sd.period         AS period,
+          sd.price          AS price,
+          p.code            AS productCode,
+          sub.idx           AS subscribeIdx,
+          sub.created_at    AS created_at,
+          sd.status         AS status,
+          sd.start_at,
+          sd.end_at,
+          (
+            SELECT pi.product_img_url
+            FROM product_image pi
+            WHERE pi.product_idx = p.code
+            LIMIT 1
+          )                   AS productImgUrl
+        FROM subscribe_detail sd
+          JOIN subscribe sub   ON sd.subscribe_idx = sub.idx
+          JOIN sale s          ON sd.sale_idx      = s.idx
+          JOIN sale_has_product shp ON s.idx       = shp.sale_idx
+          JOIN product p       ON shp.product_code = p.code
+        WHERE sub.user_id = :userId
+          AND sub.idx    IN :subscribeIds
+        GROUP BY sd.idx
+        ORDER BY sub.idx DESC, sd.idx ASC
+      """,
+            nativeQuery = true
+    )
+    List<GetSubscribeListProjection> findDetailsBySubscribeIds(
+            @Param("userId") String userId,
+            @Param("subscribeIds") List<Long> subscribeIds
+    );
+
+
 }


### PR DESCRIPTION

## #️⃣ Issue Number




## 📝 요약(Summary)

구독 보면 페이지로 불러오게 하고
구독 5개 마다 표시하는걸로 함 구독 안에 몇개가 있는 일든 구독 5개 다 표시됌 이후로 요청하고 5개 이후로 구독 불러옵니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).