### PR TITLE
[feat] 수리 신청(REPAIR), 분실 신고(LOST), 구독 연장 및 예약(REPERVED) 처리 구현

### DIFF
--- a/src/main/java/com/example/monthlylifebackend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/controller/SubscribeController.java
@@ -1,9 +1,7 @@
 package com.example.monthlylifebackend.subscribe.controller;
 
 import com.example.monthlylifebackend.common.BaseResponse;
-import com.example.monthlylifebackend.subscribe.dto.req.PostRentalDeliveryReq;
-import com.example.monthlylifebackend.subscribe.dto.req.PostReturnDeliveryReq;
-import com.example.monthlylifebackend.subscribe.dto.req.PostSubscribeReq;
+import com.example.monthlylifebackend.subscribe.dto.req.*;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeDetailInfoRes;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeListRes;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribePageResDto;
@@ -19,8 +17,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -56,7 +56,22 @@ public class SubscribeController {
     }
 
 
+    @PostMapping("/report")
+    public BaseResponse<?> report(
+            @RequestBody PostRepairOrLostReq req/*@AuthenticationPrincipal User user*/
+    ) {
+        // 간단한 필드 검증
 
+        User user = User.builder().id("1").build();
+
+        System.out.println(req.getImageUrls().size());
+        // Service에 위임
+        subscribeFacade.createReport(
+                req,
+                user
+        );
+        return BaseResponse.onSuccess(null);
+    }
 
 
 
@@ -98,9 +113,12 @@ public class SubscribeController {
     }
 
     @Operation(summary = "구독 연장", description = "구독 기간을 연장하고 계약을 갱신합니다.")
-    @PostMapping("/extend")
-    public void extendSubscription() {
-        // 구독 연장 로직
+    @PostMapping("/{detailIdx}/extend")
+    public BaseResponse extendSubscription(@PathVariable Long detailIdx, @RequestBody PostExtendRequest dto /*, @AuthenticationPrincipal User user*/ ) {
+
+        User user = User.builder().id("1").build();
+        subscribeFacade.extendSubscription(detailIdx, dto , user);
+        return BaseResponse.onSuccess(null);
     }
 
     @Operation(summary = "구독 정보 조회", description = "현재 내가 구독하고있는 목록을 확인합니다.")

--- a/src/main/java/com/example/monthlylifebackend/subscribe/dto/req/PostExtendRequest.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/dto/req/PostExtendRequest.java
@@ -1,0 +1,19 @@
+package com.example.monthlylifebackend.subscribe.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "구독 연장 요청 DTO")
+
+public class PostExtendRequest {
+
+    @Schema(description = "연장 개월수", example = "3")
+    private int extentPeriod;
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/dto/req/PostRepairOrLostReq.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/dto/req/PostRepairOrLostReq.java
@@ -1,0 +1,33 @@
+package com.example.monthlylifebackend.subscribe.dto.req;
+
+import com.example.monthlylifebackend.subscribe.model.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "수리 신청/분실 신고 요청 DTO")
+public class PostRepairOrLostReq {
+
+    @Schema(description = "구독 상세 idx", example = "3", required = true)
+    private Long subscribeDetailIdx;
+
+    @Schema(description = "신청 종류 (REPAIR or LOST)", example = "REPAIR", required = true)
+    private ReportType type;
+
+
+    @Schema(description = "신청자 이름", example = "홍길동", required = true)
+    private String subscriberName;
+
+    @Schema(description = "신청자 전화번호", example = "010-1234-5678", required = true)
+    private String subscriberPhone;
+
+    @Schema(description = "상세 설명", example = "제품이 작동하지 않습니다", required = true)
+    private String description;
+
+    private List<String> imageUrls;
+
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/facade/SubscribeFacade.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/facade/SubscribeFacade.java
@@ -4,13 +4,10 @@ package com.example.monthlylifebackend.subscribe.facade;
 import com.example.monthlylifebackend.common.customAnnotation.Facade;
 import com.example.monthlylifebackend.payment.service.BillingKeyService;
 import com.example.monthlylifebackend.payment.service.PaymentService;
-import com.example.monthlylifebackend.subscribe.dto.req.PostRentalDeliveryReq;
-import com.example.monthlylifebackend.subscribe.dto.req.PostReturnDeliveryReq;
-import com.example.monthlylifebackend.subscribe.dto.req.PostSubscribeReq;
+import com.example.monthlylifebackend.subscribe.dto.req.*;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeDetailInfoRes;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeListRes;
 import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribePageResDto;
-import com.example.monthlylifebackend.subscribe.dto.res.GetSubscribeRes;
 import com.example.monthlylifebackend.subscribe.model.Subscribe;
 import com.example.monthlylifebackend.subscribe.service.SubscribeService;
 import com.example.monthlylifebackend.user.model.User;
@@ -19,6 +16,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -66,5 +64,17 @@ public class SubscribeFacade {
     @Transactional
     public void undoCancleSubscription(User user, Long detailIdx) {
          subscribeService.undoCancleSubscription(user.getId(), detailIdx);
+    }
+
+
+
+    @Transactional
+    public void extendSubscription(Long detailIdx, PostExtendRequest dto, User user) {
+        subscribeService.extendSubscription(detailIdx,user.getId() , dto);
+    }
+
+    @Transactional
+    public void createReport(PostRepairOrLostReq req, User user) {
+        subscribeService.createRepairOrLost(req  , user.getId());
     }
 }

--- a/src/main/java/com/example/monthlylifebackend/subscribe/mapper/SubscribeMapper.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/mapper/SubscribeMapper.java
@@ -7,6 +7,7 @@ import com.example.monthlylifebackend.sale.model.Sale;
 import com.example.monthlylifebackend.sale.model.SaleHasProduct;
 import com.example.monthlylifebackend.sale.model.SalePrice;
 import com.example.monthlylifebackend.subscribe.dto.req.PostRentalDeliveryReq;
+import com.example.monthlylifebackend.subscribe.dto.req.PostRepairOrLostReq;
 import com.example.monthlylifebackend.subscribe.dto.req.PostReturnDeliveryReq;
 import com.example.monthlylifebackend.subscribe.dto.res.*;
 import com.example.monthlylifebackend.subscribe.model.RentalDelivery;
@@ -14,8 +15,11 @@ import com.example.monthlylifebackend.subscribe.model.Subscribe;
 import com.example.monthlylifebackend.subscribe.model.SubscribeDetail;
 import com.example.monthlylifebackend.subscribe.model.*;
 import com.example.monthlylifebackend.user.model.User;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
 import java.util.LinkedHashMap;
 
 import java.time.LocalDateTime;
@@ -95,6 +99,11 @@ public interface SubscribeMapper {
     @Mapping(target = "status", constant = "REQUESTED")
     ReturnDelivery toReturnDeliveryEntity(SubscribeDetail detail, PostReturnDeliveryReq postReturnDeliveryReq) ;
 
+    @Mapping(target = "idx", ignore = true)
+    @Mapping(source = "detail", target = "subscribeDetail")
+    @Mapping(target = "status", constant = "REPAIR_REQUESTED")
+    ReturnDelivery toReturnDeliveryRepair(SubscribeDetail detail) ;
+
 
     // 구독 반납
     @Mapping(source = "idx", target = "subscribeDetailIdx")
@@ -146,4 +155,24 @@ public interface SubscribeMapper {
                 })
                 .toList();
     }
+    @Mapping(target = "idx", ignore = true)
+    @Mapping(source = "detail.price", target = "price")
+    @Mapping(source = "detail.period", target = "period")
+    @Mapping(source = "detail.sale", target = "sale")
+    @Mapping(target = "startAt", source = "newStartAt")  // start_at에 현재 시간 적용
+    @Mapping(target = "endAt", source ="newEndAt" )
+    @Mapping(source = "detail.subscribe", target = "subscribe")
+    SubscribeDetail toExtendSubscription(SubscribeDetail detail, LocalDateTime newStartAt, LocalDateTime newEndAt);
+
+
+    @Mapping(target = "idx", ignore = true)
+    @Mapping(target = "status", source = "dto.type")
+    @Mapping(target = "subscriberName", source = "dto.subscriberName")
+    @Mapping(target = "subscriberPhone", source = "dto.subscriberPhone")
+    @Mapping(target = "description", source = "dto.description")
+    @Mapping(target = "subscribeDetail", source = "detail")
+    // repairImageList 는 AfterMapping 에서 builder 로 채울 거니까 무시
+    @Mapping(target = "repairImageList", ignore = true)
+    RepairRequest toEntity(PostRepairOrLostReq dto, SubscribeDetail detail);
+
 }

--- a/src/main/java/com/example/monthlylifebackend/subscribe/model/RepairImage.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/model/RepairImage.java
@@ -1,7 +1,5 @@
-package com.example.monthlylifebackend.support.model;
+package com.example.monthlylifebackend.subscribe.model;
 
-import com.example.monthlylifebackend.subscribe.model.RepairRequest;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/example/monthlylifebackend/subscribe/model/RepairRequest.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/model/RepairRequest.java
@@ -1,7 +1,6 @@
 package com.example.monthlylifebackend.subscribe.model;
 
 import com.example.monthlylifebackend.common.BaseEntity;
-import com.example.monthlylifebackend.support.model.RepairImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
@@ -20,19 +19,25 @@ public class RepairRequest extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
-
     private String description;
 
-    private String status;
 
+    @Enumerated(EnumType.STRING)
+    private ReportType status;
+
+    private String subscriberName;
+    private String subscriberPhone;
     @ManyToOne
     @JoinColumn(name = "subscribeDetail_idx")
     private SubscribeDetail subscribeDetail;
 
-    @OneToMany(mappedBy = "repairRequest")
+    @OneToMany(mappedBy = "repairRequest",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @Builder.Default
     private List<RepairImage> repairImageList = new ArrayList<>();
-
 }
+
+
+
+

--- a/src/main/java/com/example/monthlylifebackend/subscribe/model/ReportType.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/model/ReportType.java
@@ -1,0 +1,7 @@
+package com.example.monthlylifebackend.subscribe.model;
+
+public enum ReportType {
+    REPAIR,
+    LOST
+
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/model/ReturnDeliveryStatus.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/model/ReturnDeliveryStatus.java
@@ -3,7 +3,8 @@ package com.example.monthlylifebackend.subscribe.model;
 public enum ReturnDeliveryStatus {
     REQUESTED, // 요청
     CANCELED, // 요청 취소
-    COMPLETED // 요청 완료
+    COMPLETED, // 요청 완료
+    REPAIR_REQUESTED
 
 
 }

--- a/src/main/java/com/example/monthlylifebackend/subscribe/model/SubscribeStatus.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/model/SubscribeStatus.java
@@ -4,6 +4,8 @@ public enum SubscribeStatus {
     SUBSCRIBING,       // 구독 중
     RETURN_REQUESTED,  // 반납 요청
     RETURNING,         // 반납 중
-    CANCELED           // 구독 해지
-
+    CANCELED,           // 구독 해지
+    REPAIR_REQUESTED, // 수리 요청
+    RESERVED,// 구독 대기
+    LOST // 분실
 }

--- a/src/main/java/com/example/monthlylifebackend/subscribe/repository/RepairRequestRepository.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/repository/RepairRequestRepository.java
@@ -1,0 +1,10 @@
+package com.example.monthlylifebackend.subscribe.repository;
+
+import com.example.monthlylifebackend.subscribe.model.RepairRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RepairRequestRepository extends JpaRepository<RepairRequest, Integer> {
+
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/repository/SubscribeDetailRepository.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/repository/SubscribeDetailRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Modifying;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -23,6 +24,14 @@ public interface SubscribeDetailRepository extends JpaRepository<SubscribeDetail
     @Modifying
     @Query("UPDATE SubscribeDetail sd SET sd.status = :status WHERE sd.idx = :id")
     void updateStatus(@Param("id") Long id, @Param("status") SubscribeStatus status);
+    @Query("""
+    SELECT d FROM SubscribeDetail d
+    WHERE d.subscribe.idx= :subscribeId
+      AND d.status = 'SUBSCRIBING'
+      AND d.startAt <= CURRENT_TIMESTAMP
+      AND d.endAt > CURRENT_TIMESTAMP
+    ORDER BY d.endAt DESC
+""")
+    Optional<SubscribeDetail> findActiveSubscribeDetail(@Param("subscribeId") Long subscribeId);
 
-
- }
+}

--- a/src/main/java/com/example/monthlylifebackend/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/monthlylifebackend/subscribe/repository/SubscribeRepository.java
@@ -109,4 +109,5 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     );
 
 
+
 }

--- a/src/main/java/com/example/monthlylifebackend/support/repository/RepairImageRepository.java
+++ b/src/main/java/com/example/monthlylifebackend/support/repository/RepairImageRepository.java
@@ -1,6 +1,6 @@
 package com.example.monthlylifebackend.support.repository;
 
-import com.example.monthlylifebackend.support.model.RepairImage;
+import com.example.monthlylifebackend.subscribe.model.RepairImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RepairImageRepository extends JpaRepository<RepairImage, Integer> {


### PR DESCRIPTION

## #️⃣ Issue Number

lee/feat/MB-21-수리-신청

## 📝 요약(Summary)

- 수리 신청 시 이미지 리스트 등록 및 상태 변경(REPAIR_REQUESTED)
- 분실 신고 시 상태만 LOST_REQUESTED로 처리
- 구독 연장 시 새 SubscribeDetail 생성, 기존 end_at을 기준으로 이어감
- 예약된 구독(미래 start_at)은 RESERVED 상태로 설정하여 프론트에서 숨김 처리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).